### PR TITLE
Deprecation of g:airline_readonly_symbol

### DIFF
--- a/autoload/airline/extensions/taskwarrior.vim
+++ b/autoload/airline/extensions/taskwarrior.vim
@@ -1,7 +1,7 @@
 function! airline#extensions#taskwarrior#apply(...)
     if &ft == 'taskreport'
         call a:1.add_section('airline_a', ' Taskwarrior ')
-        call a:1.add_section('airline_b', ' %{b:command} %{&readonly ? g:airline_readonly_symbol : ""}')
+        call a:1.add_section('airline_b', ' %{b:command} %{&readonly ? g:airline_symbols.readonly : ""}')
         call a:1.add_section('airline_b', g:task_left_arrow.' %{b:hist > 1 ? g:task_right_arrow : ""}')
         call a:1.add_section('airline_c', ' %{b:filter} ')
         call a:1.add_section('airline_c', ' %{b:sstring} ')
@@ -23,7 +23,7 @@ function! airline#extensions#taskwarrior#apply(...)
         return 1
     elseif &ft == 'taskinfo'
         call a:1.add_section('airline_a', ' Taskinfo ')
-        call a:1.add_section('airline_b', ' %{b:command." ".g:airline_readonly_symbol }')
+        call a:1.add_section('airline_b', ' %{b:command." ".g:airline_symbols.readonly }')
         call a:1.add_section('airline_c', ' %{b:filter} ')
         call a:1.split()
         " call a:1.add_section('airline_x', '')


### PR DESCRIPTION
Recent versions of airline change the name of `g:airline_readonly_symbol` to `g:airline_symbols.readonly`, the old name is deprecated (see https://raw.githubusercontent.com/bling/vim-airline/master/autoload/airline/deprecation.vim for details).
Using the old name results in errors as soon as focus is shifted to the details view of an open task.

```
    E121: Undefined variable: g:airline_readonly_symbol
    E15: Invalid expression: b:command." ".g:airline_readonly_symbol
```

This commit adapts the variablename to the new naming convention.
