### PR TITLE
Mention option 'task_report_command' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ vnoremap <buffer> <Space> ... " add visual selected tasks to selected list
 ```vim
 " default task report type
 let g:task_report_name     = 'next'
+" custom reports have to be listed explicitly to make them available
+let g:task_report_command  = []
 " whether the field under the cursor is highlighted
 let g:task_highlight_field = 1
 " can not make change to task data when set to 1


### PR DESCRIPTION
Make clear that any custom report has to be announced to
vim-taskwarrior, according to the discussion in issue #96.

I am not sure if the list should be filled with some example, like `['my-command']`, because the other options in the README seem to just repeat the default values, and here, the default is an empty list.