### PR TITLE
Document terminal width and height workarounds properly in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,15 @@ Suggested plugins
 If you experience line-wrapping issues, add the following line to your .vimrc
 
 ```
-let g:task_rc_override = 'rc.defaultwidth=999'
+let g:task_rc_override = 'rc.defaultwidth=0'
 ```
+
+If you experience task truncation (vim-taskwarrior not showing enough tasks), add:
+
+```
+let g:task_rc_override = 'rc.defaultwidth=0'
+```
+
 
 ----
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Suggested plugins
 If you experience line-wrapping issues, add the following line to your .vimrc
 
 ```
-let g:task_rc_override = 'defaultwidth=999'
+let g:task_rc_override = 'rc.defaultwidth=999'
 ```
 
 ----

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ let g:task_rc_override = 'rc.defaultwidth=0'
 If you experience task truncation (vim-taskwarrior not showing enough tasks), add:
 
 ```
-let g:task_rc_override = 'rc.defaultwidth=0'
+let g:task_rc_override = 'rc.defaultheight=0'
 ```
 
 


### PR DESCRIPTION
In my case, I struggled with vim-taskwarrior, since it was improperly detecting both my screen height and width, so I was getting reports with limited width, and showing only few tasks.