### PR TITLE
Hack to enable neovim support

### DIFF
--- a/autoload/taskwarrior/action.vim
+++ b/autoload/taskwarrior/action.vim
@@ -85,33 +85,32 @@ function! taskwarrior#action#modify(mode)
 endfunction
 
 function! taskwarrior#action#delete()
-        let uuid = taskwarrior#data#get_uuid()
-        if uuid == ''
-            call taskwarrior#action#annotate('del')
-        else
-            let ccol = taskwarrior#data#current_column()
-            if index(['project', 'tags', 'due', 'priority', 'start', 'depends'], ccol) != -1
-                call taskwarrior#system_call(uuid, 'modify', ccol.':', 'silent')
-            else
-                if !has('nvim')
-                    execute '!task '.uuid.' delete'
-                else
-                    execute terminal 'task'.uuid.'delete'
-                endif
-            endif
-        endif
-        if !has('nvim')
+    let uuid = taskwarrior#data#get_uuid()
+    if uuid == ''
+        call taskwarrior#action#annotate('del')
+        call taskwarrior#refresh()
+    else
+        let ccol = taskwarrior#data#current_column()
+        if index(['project', 'tags', 'due', 'priority', 'start', 'depends'], ccol) != -1
+            call taskwarrior#system_call(uuid, 'modify', ccol.':', 'silent')
             call taskwarrior#refresh()
+        else
+            if has('nvim')
+                execute 'terminal task '.uuid.' delete'
+            else
+                execute '!task '.uuid.' delete'
+                call taskwarrior#refresh()
+            endif
         endif
     endif
 endfunction
 
 function! taskwarrior#action#remove()
-    if !has('nvim')
+    if has('nvim')
+        execute 'terminal task '.taskwarrior#data#get_uuid().' delete'
+    else
         execute '!task '.taskwarrior#data#get_uuid().' delete'
         call taskwarrior#list()
-    else
-        execute 'terminal task '.taskwarrior#data#get_uuid().' delete'
     endif
 endfunction
 
@@ -309,7 +308,7 @@ endfunction
 
 function! taskwarrior#action#undo()
     if has('nvim')
-        terminal task undo
+        execute 'terminal task undo'
     else
         if has("gui_running")
             if exists('g:task_gui_term') && g:task_gui_term == 1
@@ -325,9 +324,7 @@ function! taskwarrior#action#undo()
             sil !clear
             !task undo
         endif
-        if has('nvim')
-            call taskwarrior#refresh()
-        endif
+        call taskwarrior#refresh()
     endif
 endfunction
 
@@ -337,8 +334,10 @@ function! taskwarrior#action#clear_completed()
 endfunction
 
 function! taskwarrior#action#sync(action)
-    execute '!task '.a:action.' '
-    if !has('nvim')
+    if has('nvim')
+        execute 'terminal task '.a:action.' '
+    else
+        execute '!task '.a:action.' '
         call taskwarrior#refresh()
     endif
 endfunction

--- a/autoload/taskwarrior/action.vim
+++ b/autoload/taskwarrior/action.vim
@@ -337,8 +337,10 @@ function! taskwarrior#action#clear_completed()
 endfunction
 
 function! taskwarrior#action#sync(action)
-    terminal task '.a:action.' '
-    call taskwarrior#refresh()
+    execute '!task '.a:action.' '
+    if !has('nvim')
+        call taskwarrior#refresh()
+    endif
 endfunction
 
 function! taskwarrior#action#select()

--- a/autoload/taskwarrior/action.vim
+++ b/autoload/taskwarrior/action.vim
@@ -96,7 +96,7 @@ function! taskwarrior#action#delete()
             call taskwarrior#refresh()
         else
             if has('nvim')
-                execute 'terminal task '.uuid.' delete'
+                execute 'new | terminal task '.uuid.' delete'
             else
                 execute '!task '.uuid.' delete'
                 call taskwarrior#refresh()
@@ -107,7 +107,7 @@ endfunction
 
 function! taskwarrior#action#remove()
     if has('nvim')
-        execute 'terminal task '.taskwarrior#data#get_uuid().' delete'
+        execute 'new | terminal task '.taskwarrior#data#get_uuid().' delete'
     else
         execute '!task '.taskwarrior#data#get_uuid().' delete'
         call taskwarrior#list()
@@ -308,7 +308,7 @@ endfunction
 
 function! taskwarrior#action#undo()
     if has('nvim')
-        execute 'terminal task undo'
+        execute 'new | terminal task undo'
     else
         if has("gui_running")
             if exists('g:task_gui_term') && g:task_gui_term == 1
@@ -335,7 +335,7 @@ endfunction
 
 function! taskwarrior#action#sync(action)
     if has('nvim')
-        execute 'terminal task '.a:action.' '
+        execute 'new | terminal task '.a:action.' '
     else
         execute '!task '.a:action.' '
         call taskwarrior#refresh()

--- a/ftplugin/taskreport.vim
+++ b/ftplugin/taskreport.vim
@@ -143,3 +143,10 @@ endif
 command! -buffer TWToggleReadonly    :let g:task_readonly = (g:task_readonly ? 0 : 1) | call taskwarrior#refresh()
 command! -buffer TWToggleHLField     :let g:task_highlight_field = (g:task_highlight_field ? 0 : 1) | call taskwarrior#refresh()
 command! -buffer -nargs=? -complete=customlist,taskwarrior#complete#sort TWReportSort :call taskwarrior#action#sort_by_arg(<q-args>)
+
+if has('nvim')
+    augroup taskwarrior#neovim
+        autocmd!
+        autocmd BufEnter task*report call taskwarrior#refresh()
+    augroup end
+endif


### PR DESCRIPTION
This is a very first attempt at enabling neovim support for
vim-taskwarrior #132 . In my use the only functions that require interaction
are undo and delete, for these two functions there is a check
`has('nvim')` which changes execution from `!` to `terminal` and there is
also no `taskwarrior#refresh()` call, which is done using a BufEnter
autocmd.

There is likely a better solution that I don't yet know about.
