### PR TITLE
add option to disable default mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,33 +147,35 @@ vnoremap <buffer> <Space> ... " add visual selected tasks to selected list
 
 ```vim
 " default task report type
-let g:task_report_name     = 'next'
+let g:task_report_name      = 'next'
 " custom reports have to be listed explicitly to make them available
-let g:task_report_command  = []
+let g:task_report_command   = []
 " whether the field under the cursor is highlighted
-let g:task_highlight_field = 1
+let g:task_highlight_field  = 1
 " can not make change to task data when set to 1
-let g:task_readonly        = 0
+let g:task_readonly         = 0
 " vim built-in term for task undo in gvim
-let g:task_gui_term        = 1
+let g:task_gui_term         = 1
 " allows user to override task configurations. Seperated by space. Defaults to ''
-let g:task_rc_override     = 'rc.defaultwidth=999'
+let g:task_rc_override      = 'rc.defaultwidth=999'
 " default fields to ask when adding a new task
-let g:task_default_prompt  = ['due', 'description']
+let g:task_default_prompt   = ['due', 'description']
 " whether the info window is splited vertically
-let g:task_info_vsplit     = 0
+let g:task_info_vsplit      = 0
 " info window size
-let g:task_info_size       = 15
+let g:task_info_size        = 15
 " info window position
-let g:task_info_position   = 'belowright'
+let g:task_info_position    = 'belowright'
 " directory to store log files defaults to taskwarrior data.location
-let g:task_log_directory   = '~/.task'
+let g:task_log_directory    = '~/.task'
 " max number of historical entries
-let g:task_log_max         = '20'
+let g:task_log_max          = '20'
 " forward arrow shown on statusline
-let g:task_left_arrow      = ' <<'
+let g:task_left_arrow       = ' <<'
 " backward arrow ...
-let g:task_left_arrow      = '>> '
+let g:task_left_arrow       = '>> '
+" disable default mappings
+let g:task_disable_mappings = 0
 
 ```
 ----

--- a/doc/vim-tw.txt
+++ b/doc/vim-tw.txt
@@ -238,6 +238,9 @@ Default value is '>> '
                                                                *g:task_gui_term*
 Uses gvim's dumb terminal for undo commands when set to 1.
 Default value is 1
+                                                       *g:task_disable_mappings*
+Disable setting the default mappings
+Default value is 0
 
 ==============================================================================
 6. TROUBLESHOOTING                                          *tw-troubleshooting*

--- a/ftplugin/taskreport.vim
+++ b/ftplugin/taskreport.vim
@@ -76,7 +76,7 @@ endif
 
 if g:task_readonly
     setlocal readonly
-    if hasmapto('<Plug>(taskwarrior_undo)')
+    if !g:task_disable_mappings && hasmapto('<Plug>(taskwarrior_undo)')
         nunmap <silent> <buffer> A
         nunmap <silent> <buffer> x
         nunmap <silent> <buffer> o
@@ -104,32 +104,34 @@ if g:task_readonly
         vunmap <silent> <buffer> <Space>
     endif
 else
-    nmap <silent> <buffer> A        <Plug>(taskwarrior_annotate)
-    nmap <silent> <buffer> x        <Plug>(taskwarrior_denotate)
-    nmap <silent> <buffer> o        <Plug>(taskwarrior_open_annotate)
-    nmap <silent> <buffer> D        <Plug>(taskwarrior_remove)
-    nmap <silent> <buffer> <Del>    <Plug>(taskwarrior_delete)
-    nmap <silent> <buffer> a        <Plug>(taskwarrior_new)
-    nmap <silent> <buffer> c        <Plug>(taskwarrior_command)
-    nmap <silent> <buffer> d        <Plug>(taskwarrior_done)
-    nmap <silent> <buffer> r        <Plug>(taskwarrior_report)
-    nmap <silent> <buffer> R        <Plug>(taskwarrior_refresh)
-    nmap <silent> <buffer> X        <Plug>(taskwarrior_clear_completed)
-    nmap <silent> <buffer> u        <Plug>(taskwarrior_undo)
-    nmap <silent> <buffer> U        <Plug>(taskwarrior_urgency)
-    nmap <silent> <buffer> S        <Plug>(taskwarrior_sync)
-    nmap <silent> <buffer> m        <Plug>(taskwarrior_modify_field)
-    nmap <silent> <buffer> M        <Plug>(taskwarrior_modify_task)
-    nmap <silent> <buffer> p        <Plug>(taskwarrior_paste)
-    nmap <silent> <buffer> +        <Plug>(taskwarrior_start_task)
-    nmap <silent> <buffer> -        <Plug>(taskwarrior_stop_task)
-    nmap <silent> <buffer> <Space>  <Plug>(taskwarrior_select)
-    nmap <silent> <buffer> <C-A>    <Plug>(taskwarrior_increase)
-    nmap <silent> <buffer> <C-X>    <Plug>(taskwarrior_decrease)
-    vmap <silent> <buffer> d        <Plug>(taskwarrior_visual_done)
-    vmap <silent> <buffer> D        <Plug>(taskwarrior_visual_delete)
-    vmap <silent> <buffer> <Del>    <Plug>(taskwarrior_visual_delete)
-    vmap <silent> <buffer> <Space>  <Plug>(taskwarrior_visual_select)
+    if !g:task_disable_mappings
+        nmap <silent> <buffer> A        <Plug>(taskwarrior_annotate)
+        nmap <silent> <buffer> x        <Plug>(taskwarrior_denotate)
+        nmap <silent> <buffer> o        <Plug>(taskwarrior_open_annotate)
+        nmap <silent> <buffer> D        <Plug>(taskwarrior_remove)
+        nmap <silent> <buffer> <Del>    <Plug>(taskwarrior_delete)
+        nmap <silent> <buffer> a        <Plug>(taskwarrior_new)
+        nmap <silent> <buffer> c        <Plug>(taskwarrior_command)
+        nmap <silent> <buffer> d        <Plug>(taskwarrior_done)
+        nmap <silent> <buffer> r        <Plug>(taskwarrior_report)
+        nmap <silent> <buffer> R        <Plug>(taskwarrior_refresh)
+        nmap <silent> <buffer> X        <Plug>(taskwarrior_clear_completed)
+        nmap <silent> <buffer> u        <Plug>(taskwarrior_undo)
+        nmap <silent> <buffer> U        <Plug>(taskwarrior_urgency)
+        nmap <silent> <buffer> S        <Plug>(taskwarrior_sync)
+        nmap <silent> <buffer> m        <Plug>(taskwarrior_modify_field)
+        nmap <silent> <buffer> M        <Plug>(taskwarrior_modify_task)
+        nmap <silent> <buffer> p        <Plug>(taskwarrior_paste)
+        nmap <silent> <buffer> +        <Plug>(taskwarrior_start_task)
+        nmap <silent> <buffer> -        <Plug>(taskwarrior_stop_task)
+        nmap <silent> <buffer> <Space>  <Plug>(taskwarrior_select)
+        nmap <silent> <buffer> <C-A>    <Plug>(taskwarrior_increase)
+        nmap <silent> <buffer> <C-X>    <Plug>(taskwarrior_decrease)
+        vmap <silent> <buffer> d        <Plug>(taskwarrior_visual_done)
+        vmap <silent> <buffer> D        <Plug>(taskwarrior_visual_delete)
+        vmap <silent> <buffer> <Del>    <Plug>(taskwarrior_visual_delete)
+        vmap <silent> <buffer> <Space>  <Plug>(taskwarrior_visual_select)
+    endif
 
     command! -buffer TWAdd               :call taskwarrior#action#new()
     command! -buffer TWAnnotate          :call taskwarrior#action#annotate('add')

--- a/plugin/taskwarrior.vim
+++ b/plugin/taskwarrior.vim
@@ -32,6 +32,7 @@ let g:task_left_arrow               = get(g:, 'task_left_arrow', ' <<')
 let g:task_right_arrow              = get(g:, 'task_right_arrow', '>> ')
 let g:task_readonly_symbol          = get(g:, 'task_readonly_symbol', '  ')
 let g:task_gui_term                 = get(g:, 'task_gui_term', 1)
+let g:task_disable_mappings         = get(g:, 'task_disable_mappings', 0)
 let g:task_columns_format           = {
             \ 'depends':     ['list', 'count', 'indicator'],
             \ 'description': ['combined', 'desc', 'oneline', 'truncated', 'count'],


### PR DESCRIPTION
I use Colemak keyboard layout, so I need to disable default mappings and map them manually in my `.vimrc`

fixes #127 