### PR TITLE
Fixed example for defaultwidth.

### DIFF
--- a/doc/vim-tw.txt
+++ b/doc/vim-tw.txt
@@ -61,7 +61,7 @@ the vim-airline plugin (https://github.com/bling/vim-airline) is not required
 but it greatly enhances the status-bar and takes the guess-work out of reports.
 
 If you experience line-wrapping issues, add the following line to your .vimrc
-let g:task_rc_override = 'defaultwidth=999'
+let g:task_rc_override = 'rc.defaultwidth=999'
 
 ==============================================================================
 3. MAPPING                                                         *tw-mappings*


### PR DESCRIPTION
The README already show the correct example for defaultwidth-overruling. But the vim-documentation still was wrong.